### PR TITLE
Render special characters correctly

### DIFF
--- a/app/lib/stingray/console/server.ex
+++ b/app/lib/stingray/console/server.ex
@@ -81,7 +81,7 @@ defmodule Stingray.Console.Server do
   def handle_continue(:init, state) do
     port = di(Port).open(
       {:spawn, "picocom -b #{state.target.baud} #{state.serial_device_path}"},
-      [:use_stdio, :stderr_to_stdout]
+      [:binary, :use_stdio, :stderr_to_stdout]
     )
 
     {:noreply, %State{state | port: port}}


### PR DESCRIPTION
This PR fixes an issue where special characters were not rendering correctly. This was showing up in the ASCII art when booting into a target running Nerves.

**Before**

![image](https://user-images.githubusercontent.com/4755047/205474733-32d3e041-1829-4a6e-b0be-9f74520be39f.png)

**After**

![image](https://user-images.githubusercontent.com/4755047/205474722-e554f516-6721-45c1-8f2d-2590f7b18c62.png)
