### PR TITLE
Get SSH keys from GitHub

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,1 +1,6 @@
-export STINGRAY_SYSTEM_PATH=""
+# Path to a local Stingray Nerves system. (optional)
+# export STINGRAY_SYSTEM_PATH=""
+
+# GitHub users who have SSH access to Stingray. (optional)
+# Separate users with a space or new line.
+# export SSH_GITHUB_USERS=""


### PR DESCRIPTION
This PR allows for the `SSH_GITHUB_USERS` environment variable to be set with a whitespace separated list of GitHub usernames, whose public SSH keys will be allowed console access into the device.