### PR TITLE
Ignore console byte 254 to prevent BEAM process crash

### DIFF
--- a/app/lib/stingray/console/server.ex
+++ b/app/lib/stingray/console/server.ex
@@ -147,7 +147,11 @@ defmodule Stingray.Console.Server do
 
   @impl GenServer
   def handle_info({_port, {:data, console_data}}, state) do
-    IO.write console_data
+    # ASCII character 254 is invalid and causes the BEAM process to crash.
+    # This byte is received when a Nerves system reboots gracefully.
+    console_data
+    |> String.replace(<<254>>, "\n")
+    |> IO.write
 
     line = to_string(console_data)
 


### PR DESCRIPTION
Resolves #18 

This PR replaces byte `254` coming from a target with a console-friendly new line. Erlang doesn't like this byte being in an IO list.