### PR TITLE
Add the ability to power cycle a target

### DIFF
--- a/app/lib/stingray/console.ex
+++ b/app/lib/stingray/console.ex
@@ -7,6 +7,7 @@ defmodule Stingray.Console do
   Console commands start with `#` followed by a keyword. They are available
   when attached to the console of a target.
 
+  - `#cycle`  - Cycle the target's power off and on.
   - `#exit`   - Close the console to the target.
   - `#off`    - Turn off power to the target.
   - `#on`     - Turn on power to the target.

--- a/app/lib/stingray/console/command_parser.ex
+++ b/app/lib/stingray/console/command_parser.ex
@@ -11,7 +11,7 @@ defmodule Stingray.Console.CommandParser do
   @spec parse(line :: String.t) ::
       :passthrough
     | :exit
-    | {:power, :is_on? | :off | :on}
+    | {:power, :cycle | :is_on? | :off | :on}
     | :uboot
   def parse(line) when is_binary(line) do
     case String.starts_with?(line, "#") do
@@ -20,6 +20,7 @@ defmodule Stingray.Console.CommandParser do
     end
   end
 
+  defp do_parse("cycle"),        do: {:power, :cycle}
   defp do_parse("exit"),         do: :exit
   defp do_parse("off"),          do: {:power, :off}
   defp do_parse("on"),           do: {:power, :on}

--- a/app/lib/stingray/console/server.ex
+++ b/app/lib/stingray/console/server.ex
@@ -128,8 +128,7 @@ defmodule Stingray.Console.Server do
       uboot_exipration_timer: uboot_exipration_timer,
     }
 
-    di(Port).command(state.port, "\n")
-    di(Port).command(state.port, "reboot\n")
+    PowerManager.cycle
 
     {:reply, :ok, state}
   end
@@ -221,6 +220,10 @@ defmodule Stingray.Console.Server do
         :exit ->
           stingray_puts "Console closed"
           :break
+
+        {:power, :cycle} ->
+          stingray_puts "Cycling power"
+          PowerManager.cycle
 
         {:power, :is_on?} ->
           power_status = if PowerManager.power?, do: "on", else: "off"

--- a/app/lib/stingray/power_manager.ex
+++ b/app/lib/stingray/power_manager.ex
@@ -9,6 +9,13 @@ defmodule Stingray.PowerManager do
   @callback start_link(opts :: term) :: GenServer.on_start
 
   @doc """
+  Cycle a target's power off and on.
+
+  Issuing an on or off command will cancel the power cycle.
+  """
+  @callback cycle(cycle_time_in_ms :: non_neg_integer) :: :ok
+
+  @doc """
   Returns `true` if power is being supplied to the target.
   """
   @callback power?() :: boolean
@@ -35,6 +42,8 @@ defmodule Stingray.PowerManager do
   def child_spec(opts), do: %{id: __MODULE__, start: {__MODULE__, :start_link, [opts]}}
 
   def start_link(opts), do: di(__MODULE__).start_link(opts)
+
+  def cycle(cycle_time_in_ms \\ 2000), do: di(__MODULE__).cycle(cycle_time_in_ms)
 
   def power?, do: di(__MODULE__).power?
 

--- a/app/lib/stingray/power_manager/virtual.ex
+++ b/app/lib/stingray/power_manager/virtual.ex
@@ -7,6 +7,9 @@ defmodule Stingray.PowerManager.Virtual do
   use Stingray.PowerManager
 
   @impl Stingray.PowerManager
+  def cycle(_cycle_time_in_ms), do: :ok
+
+  @impl Stingray.PowerManager
   def power?, do: true
   
   @impl Stingray.PowerManager

--- a/app/spec/stingray/console/command_parser_spec.exs
+++ b/app/spec/stingray/console/command_parser_spec.exs
@@ -17,6 +17,7 @@ defmodule Stingray.Console.CommandParser.Test do
   end
 
   specify "power" do
+    expect CommandParser.parse("#cycle\n")  |> to(eq {:power, :cycle})
     expect CommandParser.parse("#off\n")    |> to(eq {:power, :off})
     expect CommandParser.parse("#on\n")     |> to(eq {:power, :on})
     expect CommandParser.parse("#power?\n") |> to(eq {:power, :is_on?})

--- a/app/spec/stingray/power_manager/driver_spec.exs
+++ b/app/spec/stingray/power_manager/driver_spec.exs
@@ -4,6 +4,8 @@ defmodule Stingray.PowerManager.Driver.Test do
   alias Stingray.PowerManager
 
   before do
+    test_pid = self()
+
     DI.inject(Stingray.PowerManager, Stingray.PowerManager.Driver)
 
     DI.inject(Circuits.GPIO, quote do
@@ -13,7 +15,10 @@ defmodule Stingray.PowerManager.Driver.Test do
       def open(_pin, _direction, _opts),
         do: raise "Unexpected args for Circuits.GPIO.open"
 
-      def write(_pin, _value), do: :ok
+      def write(_pin, value) do
+        send(unquote(test_pid), {:gpio, :write, value})
+        :ok
+      end
     end)
 
     {:ok, power_manager} = PowerManager.start_link(nil)
@@ -34,5 +39,58 @@ defmodule Stingray.PowerManager.Driver.Test do
 
     :ok = PowerManager.off
     expect PowerManager.power? |> to(eq false)
+  end
+
+  describe "cycle" do
+    it "turns a target's power off and on if the power is already on" do
+      :ok = PowerManager.on
+      expect PowerManager.power? |> to(eq true)
+      assert_received {:gpio, :write, 0}
+
+      :ok = PowerManager.cycle(1)
+      :timer.sleep(5)
+      expect PowerManager.power? |> to(eq true)
+
+      assert_receive {:gpio, :write, 1}
+      assert_receive {:gpio, :write, 0}
+    end
+
+    it "immediately turns a target's power on if the power is off" do
+      :ok = PowerManager.off
+      expect PowerManager.power? |> to(eq false)
+      assert_received {:gpio, :write, 1}
+
+      :ok = PowerManager.cycle(30)
+      expect PowerManager.power? |> to(eq true)
+
+      refute_receive {:gpio, :write, 1}
+      assert_receive {:gpio, :write, 0}
+    end
+
+    it "cancels the cycle if power on is called" do
+      :ok = PowerManager.on
+      expect PowerManager.power? |> to(eq true)
+      assert_received {:gpio, :write, 0}
+
+      :ok = PowerManager.cycle(10)
+      assert_received {:gpio, :write, 1}
+
+      :ok = PowerManager.on
+      assert_received {:gpio, :write, 0}
+      refute_receive {:gpio, :write, 0}
+    end
+
+    it "cancels the cycle if power off is called" do
+      :ok = PowerManager.on
+      expect PowerManager.power? |> to(eq true)
+      assert_received {:gpio, :write, 0}
+
+      :ok = PowerManager.cycle(10)
+      assert_received {:gpio, :write, 1}
+
+      :ok = PowerManager.off
+      assert_received {:gpio, :write, 1}
+      refute_receive {:gpio, :write, 0}
+    end
   end
 end

--- a/app/spec/stingray/power_manager/virtual_spec.exs
+++ b/app/spec/stingray/power_manager/virtual_spec.exs
@@ -16,4 +16,8 @@ defmodule Stingray.PowerManager.Vritual.Test do
     :ok = PowerManager.off
     expect PowerManager.power? |> to(eq true)
   end
+
+  it "fakes power cycling" do
+    expect PowerManager.cycle |> to(eq :ok)
+  end
 end


### PR DESCRIPTION
Resolves #3 

This PR adds the ability to power cycle a target either through `PowerManager.cycle` or the `#cycle` console command. Issuing an on or off command will cancel the power cycle. The `#uboot` console command will now power cycle as well instead of typing a reboot command.